### PR TITLE
feat: add prev_app and next_app actions

### DIFF
--- a/app/src/main/java/com/fan/edgex/action/AppActionExecutor.kt
+++ b/app/src/main/java/com/fan/edgex/action/AppActionExecutor.kt
@@ -136,6 +136,7 @@ object AppActionExecutor {
             || code == "quick_settings" -> 600L
         code.startsWith("launch_app:") || code.startsWith("app_shortcut:") -> 500L
         code == "screenshot" || code == "clear_background" || code == "refreeze" -> 300L
+        code == "prev_app" || code == "next_app" -> 500L
         else -> 150L
     }
 

--- a/app/src/main/java/com/fan/edgex/hook/GestureActionDispatcher.kt
+++ b/app/src/main/java/com/fan/edgex/hook/GestureActionDispatcher.kt
@@ -174,6 +174,12 @@ internal class GestureActionDispatcher(
             action == "kill_app" -> {
                 killForegroundApp(context)
             }
+            action == "prev_app" -> {
+                switchApp(context, forward = false)
+            }
+            action == "next_app" -> {
+                switchApp(context, forward = true)
+            }
             action == "clear_background" -> {
                 clearBackgroundApps(context)
             }
@@ -317,6 +323,8 @@ internal class GestureActionDispatcher(
         action == "lock_screen"              -> R.drawable.ic_power
         action == "expand_notifications"     -> R.drawable.ic_notifications
         action == "kill_app"                 -> R.drawable.ic_kill_app
+        action == "prev_app"                 -> R.drawable.ic_prev_app
+        action == "next_app"                 -> R.drawable.ic_next_app
         action == "clipboard"                -> R.drawable.ic_paste
         action == "universal_copy"           -> R.drawable.ic_content_copy
         action == "freezer_drawer"           -> R.drawable.ic_freezer
@@ -353,6 +361,8 @@ internal class GestureActionDispatcher(
         action == "lock_screen"       -> "Lock"
         action == "expand_notifications" -> "Notifs"
         action == "kill_app"          -> "Kill App"
+        action == "prev_app"          -> "Prev App"
+        action == "next_app"          -> "Next App"
         action == "clipboard"         -> "Clipboard"
         action == "universal_copy"    -> "Copy"
         action == "freezer_drawer"    -> "Freezer"
@@ -380,6 +390,55 @@ internal class GestureActionDispatcher(
             XposedHelpers.callMethod(activityManager, "forceStopPackage", pkg)
         } catch (e: Exception) {
             log("killForegroundApp failed: ${e.message}")
+        }
+    }
+
+    private fun switchApp(context: Context, forward: Boolean) {
+        try {
+            val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as android.app.ActivityManager
+            @Suppress("DEPRECATION")
+            val tasks = activityManager.getRunningTasks(50)
+            if (tasks.isNullOrEmpty()) return
+
+            val homePkgs = getHomeLauncherPackages(context)
+            val filtered = tasks.filter { task ->
+                val pkg = task.topActivity?.packageName ?: return@filter false
+                pkg != context.packageName && pkg !in homePkgs
+            }
+            if (filtered.size < 2) return
+
+            val currentTask = filtered[0]
+            val currentPkg = currentTask.topActivity?.packageName ?: return
+
+            val atm = getActivityTaskManagerService()
+
+            if (!forward) {
+                // prev_app: switch to most recently used app before current (MRU index 1)
+                val target = filtered[1]
+                XposedHelpers.callMethod(atm, "moveTaskToFront", target.taskId, 0, null)
+                return
+            }
+
+            // next_app: cycle through tasks sorted by package name, go to next after current
+            val sorted = filtered.sortedBy { it.topActivity?.packageName ?: "" }
+            val idx = sorted.indexOfFirst { it.topActivity?.packageName == currentPkg }
+            val nextIdx = if (idx < 0) 0 else (idx + 1) % sorted.size
+            val target = sorted[nextIdx]
+            if (target.topActivity?.packageName == currentPkg) return
+            XposedHelpers.callMethod(atm, "moveTaskToFront", target.taskId, 0, null)
+        } catch (t: Throwable) {
+            log("switchApp failed: ${t.message}")
+        }
+    }
+
+    private fun getHomeLauncherPackages(context: Context): Set<String> {
+        val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME)
+        return try {
+            context.packageManager.queryIntentActivities(intent, 0)
+                .mapNotNull { it.activityInfo?.packageName }
+                .toSet()
+        } catch (_: Throwable) {
+            emptySet()
         }
     }
 

--- a/app/src/main/java/com/fan/edgex/ui/ActionSelectionActivity.kt
+++ b/app/src/main/java/com/fan/edgex/ui/ActionSelectionActivity.kt
@@ -37,6 +37,8 @@ class ActionSelectionActivity : AppCompatActivity() {
         ActionItem(getString(R.string.action_universal_copy), "universal_copy", R.drawable.ic_content_copy),
         ActionItem(getString(R.string.action_lock_screen), "lock_screen", R.drawable.ic_power),
         ActionItem(getString(R.string.action_kill_app), "kill_app", R.drawable.ic_kill_app),
+        ActionItem(getString(R.string.action_prev_app), "prev_app", R.drawable.ic_prev_app),
+        ActionItem(getString(R.string.action_next_app), "next_app", R.drawable.ic_next_app),
         ActionItem(getString(R.string.action_brightness_up), "brightness_up", R.drawable.ic_brightness_up),
         ActionItem(getString(R.string.action_brightness_down), "brightness_down", R.drawable.ic_brightness_down),
         ActionItem(getString(R.string.action_volume_up), "volume_up", R.drawable.ic_volume_up),

--- a/app/src/main/res/drawable/ic_next_app.xml
+++ b/app/src/main/res/drawable/ic_next_app.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!-- Right arrow -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,6l6,6 -6,6z"/>
+    <!-- Stacked windows hint -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,4h-9a1,1 0,0 0,-1 1v1h8a2,2 0,0 1,2 2v9h1a1,1 0,0 0,1 -1V5a1,1 0,0 0,-1 -1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_prev_app.xml
+++ b/app/src/main/res/drawable/ic_prev_app.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <!-- Left arrow -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,6l-6,6 6,6z"/>
+    <!-- Stacked windows hint -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,4h-9a1,1 0,0 0,-1 1v1h8a2,2 0,0 1,2 2v9h1a1,1 0,0 0,1 -1V5a1,1 0,0 0,-1 -1z"/>
+</vector>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,6 +105,8 @@
     <string name="action_universal_copy">全局复制</string>
     <string name="action_lock_screen">锁定屏幕</string>
     <string name="action_kill_app">结束当前应用</string>
+    <string name="action_prev_app">上一个应用</string>
+    <string name="action_next_app">下一个应用</string>
     <string name="action_brightness_up">增加亮度</string>
     <string name="action_brightness_down">降低亮度</string>
     <string name="action_volume_up">增加音量</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,8 @@
     <string name="action_universal_copy">Global Copy</string>
     <string name="action_lock_screen">Lock Screen</string>
     <string name="action_kill_app">Kill Foreground App</string>
+    <string name="action_prev_app">Previous App</string>
+    <string name="action_next_app">Next App</string>
     <string name="action_brightness_up">Brightness Up</string>
     <string name="action_brightness_down">Brightness Down</string>
     <string name="action_volume_up">Volume Up</string>


### PR DESCRIPTION
Both actions cycle through running user apps sorted alphabetically by package name — prev_app goes backward, next_app goes forward, wrapping around. Uses ActivityManager.moveTaskToFront() directly since we run in system_server with SYSTEM_UID.