### PR TITLE
feat: add swipe gesture release trigger option

### DIFF
--- a/app/src/main/java/com/fan/edgex/config/AppConfig.kt
+++ b/app/src/main/java/com/fan/edgex/config/AppConfig.kt
@@ -5,6 +5,7 @@ object AppConfig {
 
     // Top-level flags
     const val GESTURES_ENABLED = "gestures_enabled"
+    const val GESTURE_TRIGGER_ON_RELEASE = "gesture_trigger_on_release"
     const val KEYS_ENABLED = "keys_enabled"
     const val DEBUG_MATRIX = "debug_matrix_enabled"
     const val FREEZER_ARC_DRAWER = "freezer_arc_drawer_enabled"

--- a/app/src/main/java/com/fan/edgex/hook/EdgeGestureDetector.kt
+++ b/app/src/main/java/com/fan/edgex/hook/EdgeGestureDetector.kt
@@ -18,8 +18,11 @@ internal class EdgeGestureDetector(
         fun isZoneEnabled(zone: String): Boolean
         fun resolveAction(zone: String, gestureType: String): String
         fun dispatchAction(zone: String, gestureType: String, context: Context, touchX: Float, touchY: Float)
+        fun dispatchPendingSwipeAction(zone: String, gestureType: String, context: Context, touchX: Float, touchY: Float)
+        fun onSwipeActionRecognized(context: Context)
         fun performContinuousAdjustment(action: String, context: Context, up: Boolean)
         fun isGlobalCopyModeActive(): Boolean
+        fun isTriggerOnReleaseEnabled(): Boolean
         fun log(message: String)
         fun showPie(context: Context, anchorX: Float, anchorY: Float, edge: String)
         fun updatePie(x: Float, y: Float)
@@ -63,6 +66,11 @@ internal class EdgeGestureDetector(
         var primaryGesture: String = "",
         // Pie mode: finger holds to select, release to execute
         var pieMode: Boolean = false,
+        // Pending action for trigger-on-release mode
+        var pendingSwipeGesture: String? = null,
+        var pendingSwipeAction: String? = null,
+        var swipeFurthestX: Float = 0f,  // furthest X point during swipe
+        var swipeFurthestY: Float = 0f,  // furthest Y point during swipe
     )
 
     private var activeSession: GestureSession? = null
@@ -193,6 +201,13 @@ internal class EdgeGestureDetector(
                             session.adjustmentAxis = resolveAdjustmentAxis(gestureType)
                             session.lastAdjustCoord =
                                 resolveAdjustCoord(session.adjustmentAxis ?: AdjustmentAxis.VERTICAL, event.rawX, event.rawY)
+                        } else if (callbacks.isTriggerOnReleaseEnabled()) {
+                            // Trigger-on-release mode: defer action until finger lifts
+                            session.pendingSwipeGesture = gestureType
+                            session.pendingSwipeAction = action
+                            session.swipeFurthestX = event.rawX
+                            session.swipeFurthestY = event.rawY
+                            callbacks.onSwipeActionRecognized(context)
                         } else {
                             callbacks.dispatchAction(session.zone, gestureType, context, session.targetX, session.targetY)
                         }
@@ -204,6 +219,10 @@ internal class EdgeGestureDetector(
                 }
             }
         } else {
+            // Update furthest point for trigger-on-release mode
+            if (session.pendingSwipeGesture != null) {
+                updateSwipeFurthestPoint(session, event.rawX, event.rawY)
+            }
             val continuousAction = session.continuousAction
             when {
                 continuousAction != null ->
@@ -245,7 +264,37 @@ internal class EdgeGestureDetector(
         }
 
         if (session.isSwiping) {
-            handoff.forwardToNative(session.handoff, context, event)
+            // Check if there's a pending action in trigger-on-release mode
+            val pendingGesture = session.pendingSwipeGesture
+            val pendingAction = session.pendingSwipeAction
+            if (pendingGesture != null && pendingAction != null) {
+                // Check if user swiped back enough to cancel
+                // Use distance from furthest point to current position
+                // Cancel threshold: ~24dp (half finger width, Material Design touch target is 48dp)
+                val density = context.resources.displayMetrics.density
+                val cancelThresholdPx = CANCEL_SWIPE_BACK_DP * density
+                val cancelThresholdSq = cancelThresholdPx * cancelThresholdPx
+
+                val backDx = event.rawX - session.swipeFurthestX
+                val backDy = event.rawY - session.swipeFurthestY
+                val backDistanceSq = backDx * backDx + backDy * backDy
+
+                // Check if the back movement is towards the edge direction
+                val isTowardsEdge = when (session.edge) {
+                    Edge.LEFT -> backDx < 0
+                    Edge.RIGHT -> backDx > 0
+                    Edge.TOP -> backDy < 0
+                    Edge.BOTTOM -> backDy > 0
+                }
+
+                if (isTowardsEdge && backDistanceSq >= cancelThresholdSq) {
+                    // Cancelled: swiped back towards edge enough
+                } else {
+                    callbacks.dispatchPendingSwipeAction(session.zone, pendingGesture, context, session.targetX, session.targetY)
+                }
+            } else {
+                handoff.forwardToNative(session.handoff, context, event)
+            }
             return finishSession()
         }
 
@@ -549,6 +598,35 @@ internal class EdgeGestureDetector(
         }
     }
 
+    private fun updateSwipeFurthestPoint(session: GestureSession, x: Float, y: Float) {
+        when (session.edge) {
+            Edge.LEFT -> {
+                if (x > session.swipeFurthestX) {
+                    session.swipeFurthestX = x
+                    session.swipeFurthestY = y
+                }
+            }
+            Edge.RIGHT -> {
+                if (x < session.swipeFurthestX) {
+                    session.swipeFurthestX = x
+                    session.swipeFurthestY = y
+                }
+            }
+            Edge.TOP -> {
+                if (y > session.swipeFurthestY) {
+                    session.swipeFurthestX = x
+                    session.swipeFurthestY = y
+                }
+            }
+            Edge.BOTTOM -> {
+                if (y < session.swipeFurthestY) {
+                    session.swipeFurthestX = x
+                    session.swipeFurthestY = y
+                }
+            }
+        }
+    }
+
     private fun resolveSwipeGesture(dx: Float, dy: Float): String =
         when {
             abs(dx) > abs(dy) -> if (dx < 0) "swipe_left" else "swipe_right"
@@ -596,5 +674,6 @@ internal class EdgeGestureDetector(
         const val SUB_GESTURE_SLOP_PX = 40f
         const val SUB_GESTURE_SLOP_SQ = SUB_GESTURE_SLOP_PX * SUB_GESTURE_SLOP_PX
         const val SUB_GESTURE_SEGMENT_PAUSE_MS = 120L
+        const val CANCEL_SWIPE_BACK_DP = 24f  // ~half finger width for cancel threshold
     }
 }

--- a/app/src/main/java/com/fan/edgex/hook/GestureActionDispatcher.kt
+++ b/app/src/main/java/com/fan/edgex/hook/GestureActionDispatcher.kt
@@ -117,6 +117,7 @@ internal class GestureActionDispatcher(
         context: Context,
         touchX: Float,
         touchY: Float,
+        withVibration: Boolean = true,
     ) {
         val configKey = AppConfig.gestureAction(zone, gestureType)
         var action = resolveConfig(configKey)
@@ -135,7 +136,8 @@ internal class GestureActionDispatcher(
         log("[Gesture] triggerAction key=$configKey action='$action'")
         if (action.isNotEmpty() && action != "none") {
             handlerProvider().post {
-                performAction(action, context, touchX, touchY)
+                if (withVibration) vibrateActionFeedback(context)
+                dispatchAction(action, context, touchX, touchY)
             }
         }
     }
@@ -151,6 +153,8 @@ internal class GestureActionDispatcher(
 
     fun adjustVolume(context: Context, up: Boolean) =
         com.fan.edgex.action.AppActionExecutor.adjustVolume(context, up)
+
+    fun notifySwipeRecognized(context: Context) = vibrateActionFeedback(context)
 
     private fun vibrateActionFeedback(context: Context) {
         if (resolveConfig(AppConfig.HAPTIC_FEEDBACK) != "true") return

--- a/app/src/main/java/com/fan/edgex/hook/GestureManager.kt
+++ b/app/src/main/java/com/fan/edgex/hook/GestureManager.kt
@@ -111,6 +111,25 @@ object GestureManager {
                     }
                 }
 
+                override fun dispatchPendingSwipeAction(
+                    zone: String,
+                    gestureType: String,
+                    context: Context,
+                    touchX: Float,
+                    touchY: Float,
+                ) {
+                    val action = Runnable {
+                        actionDispatcher.triggerGestureAction(zone, gestureType, context, touchX, touchY, withVibration = false)
+                    }
+                    if (!enqueueUntilFluidEffectComplete(action)) {
+                        action.run()
+                    }
+                }
+
+                override fun onSwipeActionRecognized(context: Context) {
+                    actionDispatcher.notifySwipeRecognized(context)
+                }
+
                 override fun performContinuousAdjustment(action: String, context: Context, up: Boolean) {
                     when {
                         action == "brightness_up" || action == "brightness_down" ->
@@ -122,6 +141,9 @@ object GestureManager {
 
                 override fun isGlobalCopyModeActive(): Boolean =
                     TextSelectionOverlay.isShowing()
+
+                override fun isTriggerOnReleaseEnabled(): Boolean =
+                    configRepository.get(AppConfig.GESTURE_TRIGGER_ON_RELEASE) == "true"
 
                 override fun log(message: String) {
                     gestureLog(message)

--- a/app/src/main/java/com/fan/edgex/ui/compose/screens/GesturesScreen.kt
+++ b/app/src/main/java/com/fan/edgex/ui/compose/screens/GesturesScreen.kt
@@ -185,6 +185,7 @@ fun GesturesScreen(
     )
     val removedToast = stringResource(R.string.compose_removed)
     val setActionToastTemplate = stringResource(R.string.compose_set_action_toast, "%s")
+    var triggerOnRelease by remember { mutableStateOf(context.getConfigBool(AppConfig.GESTURE_TRIGGER_ON_RELEASE)) }
 
     fun refresh() {
         state = context.readGestureScreenState()
@@ -214,6 +215,16 @@ fun GesturesScreen(
                     gesturesEnabled = it
                     context.putConfig(AppConfig.GESTURES_ENABLED, it)
                     showToast(context.getString(if (it) R.string.compose_gestures_enabled_toast else R.string.compose_gestures_disabled_toast))
+                },
+            )
+            EdgeXDivider()
+            EdgeXSwitchRow(
+                title = stringResource(R.string.compose_gesture_trigger_on_release),
+                subtitle = stringResource(R.string.compose_gesture_trigger_on_release_desc),
+                checked = triggerOnRelease,
+                onCheckedChange = {
+                    triggerOnRelease = it
+                    context.putConfig(AppConfig.GESTURE_TRIGGER_ON_RELEASE, it)
                 },
             )
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -512,6 +512,8 @@
     <string name="compose_gestures_enabled">启用手势</string>
     <string name="compose_gestures_enabled_desc">拦截屏幕边缘触摸来触发动作</string>
     <string name="compose_gestures_enabled_toast">手势已启用</string>
+    <string name="compose_gesture_trigger_on_release">划动手势抬起后触发</string>
+    <string name="compose_gesture_trigger_on_release_desc">手抬起后才触发动作；往回滑动可取消</string>
     <string name="compose_gestures_disabled_toast">手势已停用</string>
     <string name="compose_zone_enabled">启用此区域</string>
     <string name="compose_zone_thickness_width">宽度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,6 +510,8 @@
     <string name="compose_gestures_enabled">Enable Gestures</string>
     <string name="compose_gestures_enabled_desc">Intercept screen edge touches to trigger actions</string>
     <string name="compose_gestures_enabled_toast">Gestures enabled</string>
+    <string name="compose_gesture_trigger_on_release">Trigger on release</string>
+    <string name="compose_gesture_trigger_on_release_desc">Action triggers after finger lifts; swipe back to cancel</string>
     <string name="compose_gestures_disabled_toast">Gestures disabled</string>
     <string name="compose_zone_enabled">Enable this zone</string>
     <string name="compose_zone_thickness_width">Width</string>


### PR DESCRIPTION
## What
Add a "Trigger on release" option in gesture settings that delays swipe action execution until the user lifts their finger.

## Changes
- Defer swipe gesture dispatch until `ACTION_UP`
- Add haptic feedback when gesture is recognized
- Allow swipe-back-to-cancel before finger release
- Add preference toggle in Settings > Gestures

## Why
Previously, swipe gestures fired immediately on detection, which could lead to accidental triggers. This gives users more control.

## Testing
- [x] ColorOS 16 (OnePlus 15)